### PR TITLE
Add flag parser

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .DEFAULT_GOAL := all
 
 NAME=taon
+VERSION=`git describe --tags`
 
 .PHONY: help
 help: ## this help message
@@ -11,7 +12,7 @@ all: deps test build ## test and build
 
 .PHONY: build
 build: ## build the binary
-	go build -o $(NAME) -v
+	go build -ldflags "-X main.version=$(VERSION)" -o $(NAME) -v
 
 .PHONY: test
 test: ## run tests

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/olekukonko/tablewriter"
+	"gopkg.in/alecthomas/kingpin.v2"
 	"io"
 	"os"
 	"reflect"
@@ -19,11 +20,17 @@ const (
 	exitRenderTable
 )
 
+var version = "dev"
+
 func main() {
 	var r io.Reader
 	var w io.Writer
 	r = os.Stdin
 	w = os.Stdout
+
+	kingpin.Version(version)
+    kingpin.CommandLine.HelpFlag.Short('h')
+	kingpin.Parse()
 
 	header, rows, err := parseJSON(r)
 	if err != nil {


### PR DESCRIPTION
This adds [kingpin](https://github.com/alecthomas/kingpin) to parse flags with minimal available flags (`--help` and `--version`).

Closes #1  