### PR TITLE
Flatten deep JSON before printing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,8 @@ run: ## run for debug
 	@echo
 	@go run main.go columns_value.go $(PWD)/testdata/misc-array.json
 	@echo
+	@cat $(PWD)/testdata/all_docs.json | jq .rows | go run main.go columns_value.go -c key,doc._id,doc._rev,doc.name,doc.rank
+	@echo
 
 .PHONY: deps
 deps: ## install deps

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	tt "github.com/apcera/termtables"
+	ff "github.com/jeremywohl/flatten"
 	"gopkg.in/alecthomas/kingpin.v2"
 	"io"
 	"os"
@@ -112,7 +113,10 @@ func parseJSON(r io.Reader) (header Header, rows Rows, err error) {
 	for _, val := range records {
 		var rec map[string]interface{}
 		if r, ok := val.(map[string]interface{}); ok && tableble {
-			rec = r
+			rec, err = ff.Flatten(r, "", ff.DotStyle)
+			if err != nil {
+				break
+			}
 		} else {
 			rec = map[string]interface{}{"value": val}
 			tableble = false

--- a/testdata/all_docs.json
+++ b/testdata/all_docs.json
@@ -1,0 +1,7 @@
+{"total_rows":5,"offset":0,"rows":[
+{"id":"2cc1d7ac5bc7c04ad046d78dd70002a9","key":"2cc1d7ac5bc7c04ad046d78dd70002a9","value":{"rev":"1-af3f285ea2127def01455c9be6abd799"},"doc":{"_id":"2cc1d7ac5bc7c04ad046d78dd70002a9","_rev":"1-af3f285ea2127def01455c9be6abd799","name":"Alice","rank":"4"}},
+{"id":"2cc1d7ac5bc7c04ad046d78dd7000553","key":"2cc1d7ac5bc7c04ad046d78dd7000553","value":{"rev":"1-edfa1a7d98452f73bd02ed0c9a8abbdf"},"doc":{"_id":"2cc1d7ac5bc7c04ad046d78dd7000553","_rev":"1-edfa1a7d98452f73bd02ed0c9a8abbdf","name":"Bob","rank":"1"}},
+{"id":"2cc1d7ac5bc7c04ad046d78dd700093a","key":"2cc1d7ac5bc7c04ad046d78dd700093a","value":{"rev":"1-ada436f7da3b789f753ee9b1e1cead36"},"doc":{"_id":"2cc1d7ac5bc7c04ad046d78dd700093a","_rev":"1-ada436f7da3b789f753ee9b1e1cead36","name":"Chuck","rank":"3"}},
+{"id":"2cc1d7ac5bc7c04ad046d78dd70017de","key":"2cc1d7ac5bc7c04ad046d78dd70017de","value":{"rev":"1-cc8bbc24a9c34aeb1f9959dd63ce0905"},"doc":{"_id":"2cc1d7ac5bc7c04ad046d78dd70017de","_rev":"1-cc8bbc24a9c34aeb1f9959dd63ce0905","name":"David","rank":"2"}},
+{"id":"2cc1d7ac5bc7c04ad046d78dd700197f","key":"2cc1d7ac5bc7c04ad046d78dd700197f","value":{"rev":"1-080d06e9a46ec6901542970247e74fa3"},"doc":{"_id":"2cc1d7ac5bc7c04ad046d78dd700197f","_rev":"1-080d06e9a46ec6901542970247e74fa3","name":"Eve","rank":"5"}}
+]}


### PR DESCRIPTION
Adding sub-headers to table turned out to be not that trivial, so here is a lazy solution with flattening deep objects in dot-style before printing. This makes column opt more confusing, so I'll need to ponder on it, but for now this will do.

Closes: #14 